### PR TITLE
Minimal pipeline to deposit releases to s3

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,38 @@
+---
+
+resources:
+
+- name: github-release
+  type: github-release
+  source:
+    user: cf-platform-eng
+    repository: bosh-azure-template
+
+- name: s3-release
+  type: s3
+  source:
+    bucket: {{s3-bucket}}
+    regexp: .*-v(?P<version>.*)\.tgz
+    access_key_id: {{s3-access-key}}
+    secret_access_key: {{s3-secret}}
+
+jobs:
+
+- name: copy-release
+  plan:
+  - get: github-release
+    trigger: true
+  - task: copy-release
+    config:
+      platform: linux
+      image: docker:///alpine
+      inputs:
+      - name: github-release
+      outputs:
+      - name: s3-release
+      run:
+        path: sh
+        args: [ "-c", "cp github-release/*.tgz s3-release" ]
+  - put: s3-release
+    params:
+      from: s3-release/.*\.tgz

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,6 +7,7 @@ resources:
   source:
     user: cf-platform-eng
     repository: bosh-azure-template
+    access_token: {{github-access-token}}
 
 - name: s3-release
   type: s3


### PR DESCRIPTION
Here's a pipeline. It's currently deployed on dragon but depositing to one of my private buckets. To use it, create a file called ~/.azure-pipeline-creds with the following contents:

```
s3-access-key: <your-key>
s3-secret: <your-secret>
s3-bucket: <your-bucket-name>
github-access-token: <your-access-token-with-repo-access>
```

then log in to dragon with your github creds and run

`fly --target dragon set-pipeline --config pipeline.yml --pipeline azure-release --load-vars-from ~/.azure-pipeline-creds`

Voila. Every subsequent release will be automatically deposited to the s3 bucket.
