### PR TITLE
Add epehemeral disk settings to cell

### DIFF
--- a/manifests/elastic-runtime.yml
+++ b/manifests/elastic-runtime.yml
@@ -105,6 +105,10 @@ resource_pools:
     cloud_properties:
       instance_type: Standard_D2_v2
       security_group: {{ NSG_NAME_FOR_CF }}
+      ephemeral_disk:
+        use_temporary_disk: false
+        size: 20_000
+
 
   - name: errands
     network: default


### PR DESCRIPTION
Fix for issue "Diego Cell disk getting filled up and giving staging errors with InsufficientResources" as suggested by Dan Higham.
